### PR TITLE
Fix #7 Lexer using OrderedDict for TokenDef is slow

### DIFF
--- a/purplex/parse.py
+++ b/purplex/parse.py
@@ -94,7 +94,7 @@ class Parser(metaclass=ParserBase):
 
     def _build(self, start, debug):
         magic = MagicParser()
-        magic.tokens = [name for name, tokendef in self.LEXER.tokens.items()
+        magic.tokens = [name for name, tokendef in self.LEXER.tokens
                         if not tokendef.ignore]
         if self.PRECEDENCE:
             magic.precedence = self.PRECEDENCE

--- a/purplex/test/test_lexer.py
+++ b/purplex/test/test_lexer.py
@@ -26,13 +26,13 @@ def test_lex_foobar():
 
     assert tokens[0].name == 'FOO'
     assert tokens[0].value == 'foo'
-    assert tokens[0].defn == FooBarLexer.tokens['FOO']
+    assert tokens[0].defn == FooBarLexer.FOO
     assert tokens[0].line_num == 1
     assert tokens[0].line_pos == 1
 
     assert tokens[1].name == 'BAR'
     assert tokens[1].value == 'bar'
-    assert tokens[1].defn == FooBarLexer.tokens['BAR']
+    assert tokens[1].defn == FooBarLexer.BAR
     assert tokens[1].line_num == 1
     assert tokens[1].line_pos == 4
 
@@ -55,6 +55,15 @@ class LongestLexer(purplex.Lexer):
 def test_lex_longest_first():
     tokens = list(LongestLexer('foofoofoofoofoo'))
     assert [t.name for t in tokens] == ['TRIPLE_FOO', 'DOUBLE_FOO']
+
+
+class SubclassedLongestLexer(LongestLexer):
+    QUAD_FOO = purplex.TokenDef(r'foofoofoofoo')
+
+
+def test_lex_subclass_longest_first():
+    tokens = list(SubclassedLongestLexer('foofoofoofoofoo'))
+    assert [t.name for t in tokens] == ['QUAD_FOO', 'FOO']
 
 
 class TieLexer_foofirst(purplex.Lexer):


### PR DESCRIPTION
Since we can't introspect a classes attributes in the order in which
they were defined, I need to use an OrderedDict a second time to keep
track of any new TokenDefs that were added by a subclass.

In Python 3.4 class attributes will retain their ordering by default.
