### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,6 @@ $ python example.py
 [coverage-status]: https://coveralls.io/r/mtomwing/purplex "Test coverage"
 [coverage-status-badge]: https://coveralls.io/repos/mtomwing/purplex/badge.png?branch=master
 [pypi-version]: https://crate.io/packages/purplex "Latest version hosted on PyPi"
-[pypi-version-badge]: https://pypip.in/v/purplex/badge.png
+[pypi-version-badge]: https://img.shields.io/pypi/v/purplex.svg
 [pypi-downloads]: https://crate.io/packages/purplex "Number of downloads from PyPi"
-[pypi-downloads-badge]: https://pypip.in/d/purplex/badge.png
+[pypi-downloads-badge]: https://img.shields.io/pypi/dm/purplex.svg


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20purplex))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `purplex`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.